### PR TITLE
Updating FAQ with new link to Nominate

### DIFF
--- a/pages/FAQ.md
+++ b/pages/FAQ.md
@@ -25,4 +25,4 @@ You can nominate yourself (or your team) for the PSA and the PTA only. Please no
 
 You may submit a nomination for any of the three awards, namely the PSA, the PTA and the PSTM. Simply download and complete the relevant award forms, and upload them via the Nomination Portal.
 
-Click [here](/about/awards/) for more info.
+Click [here](/Nominate/) for more info.


### PR DESCRIPTION
Updated the second link in the FAQ page to redirect users to the "Nominate" page instead of the "About Awards" page.